### PR TITLE
use --no-ext-diff

### DIFF
--- a/guilt
+++ b/guilt
@@ -597,7 +597,7 @@ commit()
 		pname="$1"
 		cd_to_toplevel
 
-		git diff-files --name-only | (while read n; do git update-index "$n" ; done)
+		git diff-files --no-ext-diff --name-only | (while read n; do git update-index "$n" ; done)
 
 		# grab a commit message out of the patch
 		do_get_header "$p" > "$TMP_MSG"
@@ -715,8 +715,8 @@ push_patch()
 must_commit_first()
 {
 	git update-index --refresh --unmerged -q > /dev/null
-	[ `git diff-files | wc -l` -eq 0 ] || return $?
-	[ `git diff-index HEAD | wc -l` -eq 0 ]
+	[ `git diff-files --no-ext-diff | wc -l` -eq 0 ] || return $?
+	[ `git diff-index --no-ext-diff HEAD | wc -l` -eq 0 ]
 	return $?
 }
 
@@ -797,13 +797,13 @@ __refresh_patch()
 		if [ -n "$5" -o $diffstat = "true" ]; then
 			(
 				echo "---"
-				git diff --stat $diffopts "$2"
+				git diff --no-ext-diff --stat $diffopts "$2"
 				echo ""
 			) >> "$TMP_DIFF"
 		fi
 
 		# get the new patch
-		git diff --binary $diffopts "$2" >> "$TMP_DIFF"
+		git diff --no-ext-diff --binary $diffopts "$2" >> "$TMP_DIFF"
 
 		# move the new patch in
 		mv "$p" "$p~"

--- a/guilt-diff
+++ b/guilt-diff
@@ -28,6 +28,6 @@ PREV=HEAD^
 [ -z "`get_top`" ] && PREV=
 [ ! -z "$working_tree" ] && PREV=
 
-git diff --binary $PREV -- "$@"
+git diff --no-ext-diff --binary $PREV -- "$@"
 
 }

--- a/guilt-files
+++ b/guilt-files
@@ -51,9 +51,9 @@ fi | while read patch; do
 	IFS=' '
 	(
 		if [ "$top_patch" != "$patch" ]; then
-			git diff-tree -r $obj^ $obj
+			git diff-tree --no-ext-diff -r $obj^ $obj
 		else
-			git diff-index HEAD^
+			git diff-index --no-ext-diff HEAD^
 		fi
 	) | tr '\t' ' '|
 	while read omode nmode osha1 nsha1 st file; do

--- a/guilt-graph
+++ b/guilt-graph
@@ -52,7 +52,7 @@ fi
 
 getfiles()
 {
-	git diff-tree -r "$1^" "$1" | cut -f2
+	git diff-tree --no-ext-diff -r "$1^" "$1" | cut -f2
 }
 
 disp "digraph G {"

--- a/guilt-import-commit
+++ b/guilt-import-commit
@@ -69,7 +69,7 @@ for rev in `git rev-list $rhash`; do
 	(
 		do_make_header $rev
 		echo ""
-		git diff --binary $rev^..$rev
+		git diff --no-ext-diff --binary $rev^..$rev
 	) > "$GUILT_DIR/$branch/$fname"
 
 	# FIXME: grab the GIT_AUTHOR_DATE from the commit object and set the

--- a/guilt-new
+++ b/guilt-new
@@ -86,7 +86,7 @@ mkdir_dir=`dirname "$GUILT_DIR/$branch/$patch"`
 if [ ! -z "$force" ]; then
 	(
 		cd_to_toplevel
-		git diff --binary HEAD >> "$GUILT_DIR/$branch/$patch"
+		git diff --no-ext-diff --binary HEAD >> "$GUILT_DIR/$branch/$patch"
 	)
 fi
 

--- a/guilt-rebase
+++ b/guilt-rebase
@@ -52,7 +52,7 @@ mkdir "$rebase_dir"
 # calculate the patch ids for all the commits in upstream
 #
 for c in $inup ; do
-	git diff-tree -p $c
+	git diff-tree --no-ext-diff -p $c
 done | git patch-id | while read id name ; do
 	echo "$name" >> "$rebase_dir/$id"
 done

--- a/guilt-status
+++ b/guilt-status
@@ -105,7 +105,7 @@ git rev-parse --verify HEAD >/dev/null 2>&1 || IS_INITIAL=t
 	# added
 	if [ -z "$IS_INITIAL" ]; then
 		# non-initial commit
-		git diff-index -M --name-status --diff-filter=$DIFF_FILTER HEAD
+		git diff-index --no-ext-diff -M --name-status --diff-filter=$DIFF_FILTER HEAD
 	else
 		# initial commit
 		git ls-files | sed -e "s/^/A\t/"

--- a/regression/t-025.out
+++ b/regression/t-025.out
@@ -809,7 +809,7 @@ f da39a3ee5e6b4b0d3255bfef95601890afd80709  .git/patches/master/dir/subdir/file
 f da39a3ee5e6b4b0d3255bfef95601890afd80709  .git/patches/master/file
 f da39a3ee5e6b4b0d3255bfef95601890afd80709  .git/patches/master/prepend
 r acdeef96ee30eb34bbbf65d11de5cf7da4b5fee8  .git/refs/patches/master/prepend
-% git diff
+% git diff --no-ext-diff
 diff --git a/def b/def
 index 8baef1b..e0e56d9 100644
 --- a/def
@@ -820,7 +820,7 @@ index 8baef1b..e0e56d9 100644
 +qwerty
 % guilt new uncommitted-changes
 Uncommited changes detected. Refresh first.
-% git diff
+% git diff --no-ext-diff
 diff --git a/def b/def
 index 8baef1b..e0e56d9 100644
 --- a/def
@@ -851,7 +851,7 @@ f da39a3ee5e6b4b0d3255bfef95601890afd80709  .git/patches/master/file
 f da39a3ee5e6b4b0d3255bfef95601890afd80709  .git/patches/master/prepend
 r acdeef96ee30eb34bbbf65d11de5cf7da4b5fee8  .git/refs/patches/master/prepend
 % guilt new -f uncommitted-changes
-% git diff
+% git diff --no-ext-diff
 % guilt pop
 Now at prepend.
 % guilt push
@@ -881,8 +881,8 @@ f da39a3ee5e6b4b0d3255bfef95601890afd80709  .git/patches/master/prepend
 r acdeef96ee30eb34bbbf65d11de5cf7da4b5fee8  .git/refs/patches/master/prepend
 r d82a031e1b47908b850c7a8312300ef5cf289271  .git/refs/patches/master/uncommitted-changes
 % git update-index def
-% git diff
-% git diff HEAD
+% git diff --no-ext-diff
+% git diff --no-ext-diff HEAD
 diff --git a/def b/def
 index e0e56d9..2f766df 100644
 --- a/def
@@ -895,8 +895,8 @@ index e0e56d9..2f766df 100644
 +dvorak
 % guilt new uncommitted-changes2
 Uncommited changes detected. Refresh first.
-% git diff
-% git diff HEAD
+% git diff --no-ext-diff
+% git diff --no-ext-diff HEAD
 diff --git a/def b/def
 index e0e56d9..2f766df 100644
 --- a/def
@@ -931,8 +931,8 @@ f da39a3ee5e6b4b0d3255bfef95601890afd80709  .git/patches/master/prepend
 r acdeef96ee30eb34bbbf65d11de5cf7da4b5fee8  .git/refs/patches/master/prepend
 r d82a031e1b47908b850c7a8312300ef5cf289271  .git/refs/patches/master/uncommitted-changes
 % guilt new -f uncommitted-changes2
-% git diff
-% git diff HEAD
+% git diff --no-ext-diff
+% git diff --no-ext-diff HEAD
 % guilt pop
 Now at uncommitted-changes.
 % guilt push

--- a/regression/t-025.sh
+++ b/regression/t-025.sh
@@ -65,16 +65,16 @@ done
 
 # modify the working dir file
 cmd echo qwerty >> def
-cmd git diff
+cmd git diff --no-ext-diff
 
 # try to make a new patch, without -f
 shouldfail guilt new uncommitted-changes
-cmd git diff
+cmd git diff --no-ext-diff
 cmd list_files
 
 # give new -f, to force things
 cmd guilt new -f uncommitted-changes
-cmd git diff
+cmd git diff --no-ext-diff
 cmd guilt pop
 fixup_time_info uncommitted-changes
 cmd guilt push
@@ -83,19 +83,19 @@ cmd list_files
 # modify the working dir file (again)
 cmd echo dvorak >> def
 cmd git update-index def
-cmd git diff
-cmd git diff HEAD
+cmd git diff --no-ext-diff
+cmd git diff --no-ext-diff HEAD
 
 # try to make a new patch, without -f
 shouldfail guilt new uncommitted-changes2
-cmd git diff
-cmd git diff HEAD
+cmd git diff --no-ext-diff
+cmd git diff --no-ext-diff HEAD
 cmd list_files
 
 # give new -f, to force things
 cmd guilt new -f uncommitted-changes2
-cmd git diff
-cmd git diff HEAD
+cmd git diff --no-ext-diff
+cmd git diff --no-ext-diff HEAD
 cmd guilt pop
 fixup_time_info uncommitted-changes2
 cmd guilt push


### PR DESCRIPTION
If the user has an external diff tool set up with the diff.external config setting, than many of the guilt scripts will result in empty patches (due to "git diff" generating no output!).

This can be destructive, ie, when using guilt import-commit, which will pop the commit, and then output an empty patch file!